### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
 # app-dev
-my first repository
+**Kaibutsu Oujo/Princess Resurrection**
+
+When Hiro Hiyorimi tries to save a beautiful young woman from certain death, he ends up a dead hero himself! However, since the drop-dead girl is Hime, daughter of the King of the Monsters, his "reward" is to come back as a not-quite-living soldier in her honor guard of horror! That means helping fight off the army of supernatural monstrosities Hime's siblings are unleashing against her in hopes of moving up the ladder of succession.
+
+And if facing off with vampires and zombies isn't bad enough, how can anyone be prepared for the REALLY weird ones, like were-sharks, pandas and killer dumplings? This sure as hell isn't the afterlife Hiro was hoping for, but the really sad part is that Hime is the good girl in all of this... or at least as close to good as you can come when you're on the wrong side of the gates of hell!
+
+(Source: RightStuf)
+
+**Characters**
+- Liliane von Phoenix
+- Hiro Hiyorimi
+- Riza Wildman
+- Flandre
+- Reiri Kamura
+
+  


### PR DESCRIPTION
Kaibutsu Oujo/Princess Resurrection

When Hiro Hiyorimi tries to save a beautiful young woman from certain death, he ends up a dead hero himself! However, since the drop-dead girl is Hime, daughter of the King of the Monsters, his "reward" is to come back as a not-quite-living soldier in her honor guard of horror! That means helping fight off the army of supernatural monstrosities Hime's siblings are unleashing against her in hopes of moving up the ladder of succession.

And if facing off with vampires and zombies isn't bad enough, how can anyone be prepared for the REALLY weird ones, like were-sharks, pandas and killer dumplings? This sure as hell isn't the afterlife Hiro was hoping for, but the really sad part is that Hime is the good girl in all of this... or at least as close to good as you can come when you're on the wrong side of the gates of hell!

(Source: RightStuf)


- In the anime, members of the Royalty uses the Flame of Life to resurrect corpses. In the manga and OVA, they use their blood.

- The manga and OVA are considerably bloodier and more violent than the anime. Of course, there are still a good deal of blood in the anime where applicable.

- The characters in the anime look considerably different from their manga counterparts, while the OVA largely kept the manga's character style.
- In the manga, Ciel was activated by Zeppeli 10 hours before he ran into Flandre. In the anime its 10 days.

- In the manga, Hiro died when a van that bounced off Flandre crushed him; in the anime, he was crushed by I-beams pushing Hime out of the way.
- The order of episodes in the anime differs from the manga but has the same format of the story.

- In the anime, Ryu-Ryu is not a blood warrior but still resides with Sherwood along with the other two pandas.

https://princessresurrection.fandom.com/wiki/Kaibutsu_Oujo
